### PR TITLE
fix: add trailling comma to invocation

### DIFF
--- a/lib/src/emitters/invoke.dart
+++ b/lib/src/emitters/invoke.dart
@@ -19,7 +19,7 @@ class InvokeEmitter extends Emitter<Invoke> {
     for (final v in value.elements) {
       ElementEmitter(context).emit(v, output);
 
-      if (v != value.elements.last) {
+      if (v != value.elements.last || context.useTraillingCommas) {
         output.write(', ');
       }
     }

--- a/test/src/emitters/invoke_test.dart
+++ b/test/src/emitters/invoke_test.dart
@@ -48,6 +48,28 @@ void main() {
           );
         },
       );
+
+      test(
+        'should emit an invocation with a trailling comma',
+        () {
+          const context = Context(useTraillingCommas: true);
+
+          const element = Invoke([
+            LiteralString('Pip'),
+            LiteralNum(8),
+          ]);
+
+          Expect(
+            element,
+            const Equals(
+              '''
+                ('Pip', 8, )
+              ''',
+              emitter: InvokeEmitter(context),
+            ),
+          );
+        },
+      );
     },
   );
 }


### PR DESCRIPTION
## Status

**READY*

closes #46 

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
