### PR TITLE
fix: only use trailling comma when more than 1 el

### DIFF
--- a/lib/src/emitters/enum.dart
+++ b/lib/src/emitters/enum.dart
@@ -31,7 +31,7 @@ class EnumEmitter extends Emitter<Enum> {
     for (final v in element.values) {
       EnumValueEmitter(context).emit(v, output);
 
-      if (v != element.values.last || context.useTraillingCommas) {
+      if (v != element.values.last) {
         output.write(' , ');
       }
     }

--- a/lib/src/emitters/invoke.dart
+++ b/lib/src/emitters/invoke.dart
@@ -7,6 +7,12 @@ class InvokeEmitter extends Emitter<Invoke> {
   /// {@macro invoke_emitter}
   const InvokeEmitter(super.context);
 
+  bool useTraillingCommas(
+    Invoke element,
+  ) {
+    return context.useTraillingCommas && element.elements.length > 1;
+  }
+
   @override
   StringSink emit(
     Invoke element, [
@@ -19,7 +25,7 @@ class InvokeEmitter extends Emitter<Invoke> {
     for (final v in element.elements) {
       ElementEmitter(context).emit(v, output);
 
-      if (v != element.elements.last || context.useTraillingCommas) {
+      if (v != element.elements.last || useTraillingCommas(element)) {
         output.write(', ');
       }
     }

--- a/lib/src/emitters/parameter.dart
+++ b/lib/src/emitters/parameter.dart
@@ -61,6 +61,12 @@ class ParameterListEmitter extends Emitter<List<Parameter>> {
     }
   }
 
+  bool useTraillingCommas(
+    List<Parameter> elements,
+  ) {
+    return context.useTraillingCommas && elements.length > 1;
+  }
+
   @override
   StringSink emit(
     List<Parameter> elements, [
@@ -80,7 +86,7 @@ class ParameterListEmitter extends Emitter<List<Parameter>> {
 
       ParameterEmitter(context).emit(curr, output);
 
-      if (curr != elements.last || context.useTraillingCommas) {
+      if (curr != elements.last || useTraillingCommas(elements)) {
         output.write(', ');
       }
 

--- a/test/src/emitters/enum_test.dart
+++ b/test/src/emitters/enum_test.dart
@@ -60,36 +60,6 @@ void main() {
       );
 
       test(
-        'should emit an enum with values and a trailling comma',
-        () {
-          const element = Enum(
-            name: 'CatState',
-            values: [
-              EnumValue('sleep'),
-              EnumValue('eat'),
-              EnumValue('purr'),
-            ],
-          );
-
-          Expect(
-            element,
-            const Equals(
-              '''
-                enum CatState {
-                  sleep,
-                  eat,
-                  purr,
-                }
-              ''',
-              emitter: EnumEmitter(
-                Context(useTraillingCommas: true),
-              ),
-            ),
-          );
-        },
-      );
-
-      test(
         'should emit an enum with docs',
         () {
           const element = Enum(

--- a/test/src/emitters/invoke_test.dart
+++ b/test/src/emitters/invoke_test.dart
@@ -50,7 +50,30 @@ void main() {
       );
 
       test(
-        'should emit an invocation with a trailling comma',
+        'should emit an invocation without a trailling comma when only one '
+        'element is present',
+        () {
+          const context = Context(useTraillingCommas: true);
+
+          const element = Invoke([
+            LiteralString('Pip'),
+          ]);
+
+          Expect(
+            element,
+            const Equals(
+              '''
+                ('Pip')
+              ''',
+              emitter: InvokeEmitter(context),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should emit an invocation with a trailling comma when multiple '
+        'elements are present',
         () {
           const context = Context(useTraillingCommas: true);
 

--- a/test/src/emitters/parameter_test.dart
+++ b/test/src/emitters/parameter_test.dart
@@ -192,7 +192,33 @@ void main() {
       );
 
       test(
-        'should emit a list of parameters with a trailling comma',
+        'should emit a list of parameters without a trailling comma when one '
+        'element is present',
+        () {
+          const elements = [
+            Parameter(
+              name: 'name',
+              type: TypeReference('dynamic'),
+            ),
+          ];
+
+          Expect(
+            elements,
+            const Equals(
+              '''
+                dynamic name
+              ''',
+              emitter: ParameterListEmitter(
+                Context(useTraillingCommas: true),
+              ),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should emit a list of parameters with a trailling comma when multiple '
+        'elements are present',
         () {
           const elements = [
             Parameter(


### PR DESCRIPTION
## Status

**READY**

## Description

closes #97 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
